### PR TITLE
Allow debug to be overriden

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ var loaderUtils = require("loader-utils");
 var yaml = require('js-yaml');
 
 module.exports = function (source) {
+	const options = loaderUtils.getOptions(this);
+	const debug = options.hasOwnProperty('debug') ? options.debug : this.debug;
+	
 	if (this.cacheable) this.cacheable();
 	var callback = this.async();
 
@@ -17,7 +20,7 @@ module.exports = function (source) {
 	var compiler = new KaitaiStructCompiler();
 	var kaitaiImport = 'var KaitaiStream = require("kaitai-struct/KaitaiStream")\n';
 
-	compiler.compile("javascript", structure, null, this.debug).then(function (code) {
+	compiler.compile("javascript", structure, null, debug).then(function (code) {
 		callback(null, kaitaiImport + Object.values(code).join('\n'), null);
 	}).catch(function (error) {
 		callback(new Error(error), null);


### PR DESCRIPTION
Previously enabling debug was managed by using the option `--debug` when calling Webpack. However, this setting is global and applies to all loaders. By using `loader-utils` it is possible to individually set it.

For example:

```
module: {
    rules: [
        {
            test: /\.ksy$/,
            use: [{
                loader: 'kaitai-struct-loader',
                options: { debug: true }
            }],
        }
    ]
}
```