### PR TITLE
Bump to latest kaitai-struct{-compiler} versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,9 @@ module.exports = function (source) {
 	}
 
 	var compiler = new KaitaiStructCompiler();
-	var kaitaiImport = 'var KaitaiStream = require("kaitai-struct/KaitaiStream")\n';
 
 	compiler.compile("javascript", structure, null, debug).then(function (code) {
-		callback(null, kaitaiImport + Object.values(code).join('\n'), null);
+		callback(null, Object.values(code).join('\n'), null);
 	}).catch(function (error) {
 		callback(new Error(error), null);
 	});

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "js-yaml": "^3.9.0",
-    "kaitai-struct": "^0.8.0-SNAPSHOT.2",
-    "kaitai-struct-compiler": "^0.7.1"
+    "kaitai-struct": "^0.9.0-SNAPSHOT.1",
+    "kaitai-struct-compiler": "^0.8.0-SNAPSHOT.20180205.11616"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,30 +3,36 @@
 
 
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
 esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 js-yaml@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-kaitai-struct-compiler@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/kaitai-struct-compiler/-/kaitai-struct-compiler-0.7.1.tgz#6f527beec86e05301394a425d7de7e0c84c03e4f"
+kaitai-struct-compiler@^0.8.0-SNAPSHOT.20180205.11616:
+  version "0.8.0-SNAPSHOT.20180205.11616"
+  resolved "https://registry.yarnpkg.com/kaitai-struct-compiler/-/kaitai-struct-compiler-0.8.0-SNAPSHOT.20180205.11616.tgz#25975bf13d1b4e36244bc74e129fe99e76536881"
+  integrity sha1-JZdb8T0bTjYkS8dOEp/pnnZTaIE=
 
-kaitai-struct@^0.8.0-SNAPSHOT.2:
-  version "0.8.0-SNAPSHOT.2"
-  resolved "https://registry.yarnpkg.com/kaitai-struct/-/kaitai-struct-0.8.0-SNAPSHOT.2.tgz#225a2618349437653897a13e06e683078cd70c2d"
+kaitai-struct@^0.9.0-SNAPSHOT.1:
+  version "0.9.0-SNAPSHOT.1"
+  resolved "https://registry.yarnpkg.com/kaitai-struct/-/kaitai-struct-0.9.0-SNAPSHOT.1.tgz#fb593095a1a3e50fa8edadb6194da62c7cc5467c"
+  integrity sha512-+xJH3mcSPxfxTrd+MycNaLfEtBAVeRNveKF0jW6J67wFnz6IVeG5Agki2emqWuVHMuymqWtFVJkrFRLRcbzFsQ==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=


### PR DESCRIPTION
The import is no longer needed as the module generated by the compiler handles this for us.

Fixes #3 