### PR TITLE
add ksy import support

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var yaml = require('js-yaml');
 var path = require('path');
 var fs = require('fs');
 
-// Please note, that this function is called from webpack, and 'this' will
-// refer to https://webpack.js.org/api/loaders/#the-loader-context
+// this function is called from webpack and 'this' refers
+// to https://webpack.js.org/api/loaders/#the-loader-context
 module.exports = function (source) {
 	const options = loaderUtils.getOptions(this) || {};
 	const debug = options.hasOwnProperty('debug') ? options.debug : this.debug;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (source) {
 
 	var yamlImporter = {
 		importYaml: function(name, mode) {
-			const filePath = path.join(context, name + ".ksy");
+			const filePath = path.join(moduleDir, name + ".ksy");
 			const ksyStr = fs.readFileSync(filePath, "utf8");
 			const ksyObj = yaml.safeLoad(ksyStr);
 			return Promise.resolve(ksyObj);

--- a/index.js
+++ b/index.js
@@ -18,10 +18,8 @@ module.exports = function (source) {
 	}
 
 	var compiler = new KaitaiStructCompiler();
-	var kaitaiImport = 'var KaitaiStream = require("kaitai-struct/KaitaiStream")\n';
-
 	compiler.compile("javascript", structure, null, debug).then(function (code) {
-		callback(null, kaitaiImport + Object.values(code).join('\n'), null);
+		callback(null, Object.values(code).join('\n'), null);
 	}).catch(function (error) {
 		callback(new Error(error), null);
 	});

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ var yaml = require('js-yaml');
 var path = require('path');
 var fs = require('fs');
 
+// Please note, that this function is called from webpack, and 'this' will
+// refer to https://webpack.js.org/api/loaders/#the-loader-context
 module.exports = function (source) {
 	const options = loaderUtils.getOptions(this) || {};
 	const debug = options.hasOwnProperty('debug') ? options.debug : this.debug;

--- a/index.js
+++ b/index.js
@@ -21,13 +21,13 @@ module.exports = function (source) {
 
 	const context = this.context;
 
-    var yamlImporter = {
-        importYaml: function(name, mode) {
-            return Promise.resolve(
+	var yamlImporter = {
+		importYaml: function(name, mode) {
+			return Promise.resolve(
 				yaml.safeLoad(fs.readFileSync(path.join(context, name + ".ksy"), "utf8"))
 			);
-        }
-    };
+		}
+	};
 
 	var compiler = new KaitaiStructCompiler();
 	compiler.compile("javascript", structure, yamlImporter, debug).then(function (code) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var KaitaiStructCompiler = require("kaitai-struct-compiler");
 var loaderUtils = require("loader-utils");
 var yaml = require('js-yaml');
+var path = require('path');
+var fs = require('fs');
 
 module.exports = function (source) {
 	const options = loaderUtils.getOptions(this) || {};
@@ -17,8 +19,18 @@ module.exports = function (source) {
 		return;
 	}
 
+	const context = this.context;
+
+    var yamlImporter = {
+        importYaml: function(name, mode) {
+            return Promise.resolve(
+				yaml.safeLoad(fs.readFileSync(path.join(context, name + ".ksy"), "utf8"))
+			);
+        }
+    };
+
 	var compiler = new KaitaiStructCompiler();
-	compiler.compile("javascript", structure, null, debug).then(function (code) {
+	compiler.compile("javascript", structure, yamlImporter, debug).then(function (code) {
 		callback(null, Object.values(code).join('\n'), null);
 	}).catch(function (error) {
 		callback(new Error(error), null);

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (source) {
 		return;
 	}
 
-	const context = this.context;
+	const moduleDir = this.context;
 
 	var yamlImporter = {
 		importYaml: function(name, mode) {

--- a/index.js
+++ b/index.js
@@ -25,9 +25,10 @@ module.exports = function (source) {
 
 	var yamlImporter = {
 		importYaml: function(name, mode) {
-			return Promise.resolve(
-				yaml.safeLoad(fs.readFileSync(path.join(context, name + ".ksy"), "utf8"))
-			);
+			const filePath = path.join(context, name + ".ksy");
+			const ksyStr = fs.readFileSync(filePath, "utf8");
+			const ksyObj = yaml.safeLoad(ksyStr);
+			return Promise.resolve(ksyObj);
 		}
 	};
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "js-yaml": "^3.9.0",
-    "kaitai-struct": "^0.8.0-SNAPSHOT.2",
-    "kaitai-struct-compiler": "^0.7.1"
+    "kaitai-struct": "^0.9.0",
+    "kaitai-struct-compiler": "^0.9.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,13 +19,15 @@ js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-kaitai-struct-compiler@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/kaitai-struct-compiler/-/kaitai-struct-compiler-0.7.1.tgz#6f527beec86e05301394a425d7de7e0c84c03e4f"
+kaitai-struct-compiler@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/kaitai-struct-compiler/-/kaitai-struct-compiler-0.9.0.tgz#90ff9cd0f0ea0ec4f8532de2ca1e2439df6999be"
+  integrity sha512-KA1rRv6FjUl/J8UfLhpvgtG3UGx6mDh6/Q1uC+/CSr3RsK4ejvDehY59DjQSNF3iNtzHo6kvptoa9XmUD3gIrg==
 
-kaitai-struct@^0.8.0-SNAPSHOT.2:
-  version "0.8.0-SNAPSHOT.2"
-  resolved "https://registry.yarnpkg.com/kaitai-struct/-/kaitai-struct-0.8.0-SNAPSHOT.2.tgz#225a2618349437653897a13e06e683078cd70c2d"
+kaitai-struct@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/kaitai-struct/-/kaitai-struct-0.9.0.tgz#07264320f7aa4fa4c9d6b261495f483ab1af569b"
+  integrity sha512-mfoBu9+IGqaY3ykG1TyAy9omOAZWtheqESQOvo/HKIQVTz+gRPVCNBnhjbO+8wAQ77RD33wYvLBWmITuXIviQg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This pull request implements support for importing ksy files from another ksy file. Relative paths (from the file you are importing from) is supported, absolute paths (as described in the kaitai docs) are not yet supported (but could be implemented in a later MR),.

This also updates the compiler to the 0.9.0 release.